### PR TITLE
Add raw data from the paper

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -2,3 +2,8 @@
 
 This CSV file contains the data used in the coupled-network and single-network experiments. Each row in the data file corresponds to one trained model
 and the hyperparameters, random seed, generalization errors, and generalization measures are reported. There are 10000 models in total.
+
+
+## Download Pytorch-formatted models
+
+The models corresponding to the CSV file can be downloaded at **TODO**

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,4 @@
+# Data
+
+This CSV file contains the data used in the coupled-network and single-network experiments. Each row in the data file corresponds to one trained model
+and the hyperparameters, random seed, generalization errors, and generalization measures are reported. There are 10000 models in total.


### PR DESCRIPTION
This is the data file used in the coupled-net and single-net experiments. A URL to download the raw models will be added as soon as we figure out the technical details for hosting.